### PR TITLE
Add basic docs and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,33 @@
 # AIgentChat-Dspy-light
 
-This project provides a simplified backend demonstrating a multi-agent research system. It uses OpenAI via LangChain and DSPy for prompt optimization.
+This project provides a simplified backend demonstrating a multi-agent research system. It uses OpenAI through LangChain and DSPy for prompt optimization.
 
-## Usage
+- [Installation](docs/installation.md)
+- [Usage](docs/usage.md)
+- [Troubleshooting](docs/troubleshooting.md)
 
-1. Install dependencies
-   ```bash
-   pip install -r requirements.txt
-   ```
-2. Create default templates if they do not exist
-   ```bash
-   python create_templates.py
-   ```
-3. Export your `OPENAI_API_KEY` and run the simulation
-   ```bash
-   export OPENAI_API_KEY=sk-...
-   python main.py
-   ```
+## Architecture Overview
+
+The core of the system lives in `integrated_system.py`. A `PopulationGenerator` first builds agent specifications which are used by the `GodAgent` to spawn `PopulationAgent` instances. A single `WizardAgent` converses with each population agent and submits logs to an `EnhancedJudgeAgent` for scoring. The `TokenTracker` and `StructuredLogger` record usage statistics and events.
+
+```
+PopulationGenerator -> GodAgent -> PopulationAgent
+                               \-> WizardAgent -> EnhancedJudgeAgent
+```
+
+`main.py` wires these components together and exposes a command line interface.
+
+## Quick Start
+
+Install dependencies and templates then run the analysis simulation:
+```bash
+pip install -r requirements.txt
+python create_templates.py  # if templates are missing
+export OPENAI_API_KEY=sk-...
+python main.py
+```
+
+To launch the (currently experimental) dashboard run:
+```bash
+python main.py --dashboard
+```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,22 @@
+# Installation
+
+Follow these steps to set up the project locally.
+
+1. Clone the repository and change into the directory.
+   ```bash
+   git clone <repo-url>
+   cd AIgentChat-Dspy-light
+   ```
+2. Install Python dependencies.
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Optionally create default templates if you have not done so.
+   ```bash
+   python create_templates.py
+   ```
+4. Set your OpenAI API key.
+   ```bash
+   export OPENAI_API_KEY=sk-...
+   ```
+

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,19 @@
+# Troubleshooting
+
+Common issues and how to resolve them.
+
+## Missing OpenAI key
+If you encounter `Missing OPENAI_API_KEY` errors, ensure that the environment variable is set:
+```bash
+export OPENAI_API_KEY=sk-...
+```
+
+## Templates not found
+If the system reports missing template files, generate them with:
+```bash
+python create_templates.py
+```
+
+## API connection errors
+Network or authentication problems may cause OpenAI API requests to fail. Verify your API key and internet connection.
+

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,20 @@
+# Usage
+
+This project demonstrates a simplified multi-agent research system. Once the dependencies are installed and the `OPENAI_API_KEY` is exported, you can run the simulation or launch the dashboard.
+
+## Running the analysis simulation
+
+```bash
+python main.py
+```
+
+The system will generate a population of agents and simulate conversations with them using the integrated agent framework.
+
+## Starting the (experimental) dashboard
+
+```bash
+python main.py --dashboard
+```
+
+The dashboard is currently a placeholder and will simply print a message that it is not yet implemented.
+


### PR DESCRIPTION
## Summary
- create `docs/` folder with installation, usage, and troubleshooting guides
- describe core architecture in `README` and link to the docs
- show how to run the analysis simulation or dashboard from the command line

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866e89bce608324b7ef6353164f6cf0