### PR TITLE
Fix docs references and cleanup README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,23 +17,6 @@ PopulationGenerator -> GodAgent -> PopulationAgent
 
 `main.py` wires these components together and exposes a command line interface.
 
-## Quick Start
-
-Install dependencies and templates then run the analysis simulation:
-```bash
-pip install -r requirements.txt
-python create_templates.py  # if templates are missing
-export OPENAI_API_KEY=sk-...
-python main.py
-```
-
-To launch the (currently experimental) dashboard run:
-```bash
-python main.py --dashboard
-```
-=======
-This project provides a simplified backend demonstrating a multi-agent research system. It uses OpenAI via LangChain and DSPy for prompt optimization.
-
 ## Usage
 
 1. Install dependencies

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,7 +13,7 @@ Follow these steps to set up the project locally.
    ```
 3. Optionally create default templates if you have not done so.
    ```bash
-   python create_templates.py
+   python scripts/create_templates.py
    ```
 4. Set your OpenAI API key.
    ```bash

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -11,7 +11,7 @@ export OPENAI_API_KEY=sk-...
 ## Templates not found
 If the system reports missing template files, generate them with:
 ```bash
-python create_templates.py
+python scripts/create_templates.py
 ```
 
 ## API connection errors


### PR DESCRIPTION
## Summary
- remove duplicate project intro and Quick Start from README
- reference `scripts/create_templates.py` everywhere

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866eb44a0688324a896ee55b92830fd