### PR TITLE
Implement minimal dashboard Flask app

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ To launch the (currently experimental) dashboard run:
 ```bash
 python main.py --dashboard
 ```
-=======
+This will start a simple Flask app that displays a placeholder page.
+
 This project provides a simplified backend demonstrating a multi-agent research system. It uses OpenAI via LangChain and DSPy for prompt optimization.
 
 ## Usage

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -16,5 +16,6 @@ The system will generate a population of agents and simulate conversations with 
 python main.py --dashboard
 ```
 
-The dashboard is currently a placeholder and will simply print a message that it is not yet implemented.
+This will start a minimal Flask application that serves a placeholder page at the root URL.
+
 

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import config
 from core.utils import ensure_logs_dir
 from core.integrated_system import IntegratedSystem
+from web import create_app
 
 
 def validate_environment():
@@ -33,7 +34,8 @@ def main():
     parser.add_argument("--dashboard", action="store_true")
     args = parser.parse_args()
     if args.dashboard:
-        print("Dashboard not implemented")
+        app = create_app()
+        app.run(debug=True)
     else:
         run_simulation()
 

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -1,0 +1,12 @@
+from flask import Flask
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+
+    @app.route('/')
+    def index():
+        return 'Dashboard placeholder'
+
+    return app
+


### PR DESCRIPTION
## Summary
- add `web/` package exposing `create_app()`
- start Flask app in `main.py` when `--dashboard` is used
- document dashboard behavior in README and usage docs

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866eb4606588324ba6c17c1c877b4ad