### PR TITLE
Mock OpenAI in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,13 @@ The main application writes to `logs/system.log` and `logs/token_usage.json`.
 
 Use the helper script `scripts/clean_logs.py` to archive or clear old log files.
 
+## Running tests
+
+The test suite uses mocked API calls and does not require an OpenAI key. After
+installing the dependencies simply run:
+
+```bash
+pytest
+```
+
+


### PR DESCRIPTION
## Summary
- mock OpenAI client in `tests/test_api.py`
- describe running tests in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866eb4ff41883248167435e09eba7d4