### PR TITLE
Fix template creation path in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ PopulationGenerator -> GodAgent -> PopulationAgent
 Install dependencies and templates then run the analysis simulation:
 ```bash
 pip install -r requirements.txt
-python create_templates.py  # if templates are missing
+python scripts/create_templates.py  # if templates are missing
 export OPENAI_API_KEY=sk-...
 python main.py
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,7 +13,7 @@ Follow these steps to set up the project locally.
    ```
 3. Optionally create default templates if you have not done so.
    ```bash
-   python create_templates.py
+   python scripts/create_templates.py
    ```
 4. Set your OpenAI API key.
    ```bash

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -11,7 +11,7 @@ export OPENAI_API_KEY=sk-...
 ## Templates not found
 If the system reports missing template files, generate them with:
 ```bash
-python create_templates.py
+python scripts/create_templates.py
 ```
 
 ## API connection errors


### PR DESCRIPTION
## Summary
- update path in installation instructions to `python scripts/create_templates.py`
- correct troubleshooting guidance
- keep README consistent

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866eb55d4288324b068614889b08bd9