### PR TITLE
Remove debugCORS script and add CORS troubleshooting docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__/
 
 logs/*
 !logs/.gitkeep
+
+scripts/debugCORS.py

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -17,3 +17,21 @@ python create_templates.py
 ## API connection errors
 Network or authentication problems may cause OpenAI API requests to fail. Verify your API key and internet connection.
 
+## Debugging CORS issues
+
+Earlier versions of the project included a helper script `scripts/debugCORS.py` for testing cross-origin behavior. The file has been removed, but its functionality can be recreated with this minimal Flask snippet:
+
+```python
+from flask import Flask
+app = Flask(__name__)
+
+@app.route('/')
+def index():
+    return 'OK'
+
+if __name__ == '__main__':
+    app.run(debug=True)
+```
+
+Run it locally whenever you need a quick server to troubleshoot CORS problems.
+

--- a/scripts/debugCORS.py
+++ b/scripts/debugCORS.py
@@ -1,9 +1,0 @@
-from flask import Flask
-app = Flask(__name__)
-
-@app.route('/')
-def index():
-    return 'OK'
-
-if __name__ == '__main__':
-    app.run(debug=True)


### PR DESCRIPTION
## Summary
- remove `scripts/debugCORS.py`
- ignore recreated `debugCORS` helper script
- document how to debug CORS issues in troubleshooting guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866eb533df083249d45baab2b3a9500