### PR TITLE
Expose new config options via .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,25 @@ OPENAI_API_KEY=sk-...
 
 # Optional: specify model (defaults to gpt-4.1-nano)
 LLM_MODEL=gpt-4.1-nano
+
+# Size of the agent population
+POPULATION_SIZE=36
+
+# Comma separated conversation numbers after which the wizard self-improves
+SELF_IMPROVE_AFTER=1,10,35
+
+# Control concurrency; set to "false" to run conversations sequentially
+PARALLEL_CONVERSATIONS=true
+
+# DSPy optimizer batch sizes
+DSPY_MIPRO_MINIBATCH_SIZE=4
+DSPY_BOOTSTRAP_MINIBATCH_SIZE=2
+
+# Number of turns per conversation
+MAX_TURNS=6
+
+# Maximum entries in the wizard history buffer
+HISTORY_BUFFER_LIMIT=50
+
+# Logging verbosity
+LOG_LEVEL=INFO

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This project provides a simplified backend demonstrating a multi-agent research 
 
 - [Installation](docs/installation.md)
 - [Usage](docs/usage.md)
+- [Configuration](docs/configuration.md)
 - [Troubleshooting](docs/troubleshooting.md)
 
 ## Architecture Overview
@@ -47,8 +48,10 @@ This project provides a simplified backend demonstrating a multi-agent research 
 3. Copy `.env.example` to `.env` and update the values
    ```bash
    cp .env.example .env
-   # edit .env and set OPENAI_API_KEY
+   # edit `.env` and set OPENAI_API_KEY and other options
    ```
+   Additional environment variables are described in
+   [docs/configuration.md](docs/configuration.md).
 4. Run the simulation
    ```bash
    python main.py

--- a/config.py
+++ b/config.py
@@ -1,18 +1,21 @@
 import os
 from typing import List
 
-# Basic configuration
-POPULATION_SIZE = 36
-SELF_IMPROVE_AFTER: List[int] = [1, 10, 35]
+# Basic configuration loaded from environment variables
+POPULATION_SIZE = int(os.environ.get("POPULATION_SIZE", 36))
+SELF_IMPROVE_AFTER: List[int] = [
+    int(x) for x in os.environ.get("SELF_IMPROVE_AFTER", "1,10,35").split(",") if x
+]
 LLM_MODEL = os.environ.get("LLM_MODEL", "gpt-4.1-nano")
-PARALLEL_CONVERSATIONS = True
+PARALLEL_CONVERSATIONS = os.environ.get("PARALLEL_CONVERSATIONS", "true").lower() == "true"
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
+LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO")
 
 # DSPy optimizer settings
-DSPY_MIPRO_MINIBATCH_SIZE = 4
-DSPY_BOOTSTRAP_MINIBATCH_SIZE = 2
-MAX_TURNS = 6
-HISTORY_BUFFER_LIMIT = 50
+DSPY_MIPRO_MINIBATCH_SIZE = int(os.environ.get("DSPY_MIPRO_MINIBATCH_SIZE", 4))
+DSPY_BOOTSTRAP_MINIBATCH_SIZE = int(os.environ.get("DSPY_BOOTSTRAP_MINIBATCH_SIZE", 2))
+MAX_TURNS = int(os.environ.get("MAX_TURNS", 6))
+HISTORY_BUFFER_LIMIT = int(os.environ.get("HISTORY_BUFFER_LIMIT", 50))
 
 
 class ConfigError(Exception):

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,18 @@
+# Configuration
+
+The application can be customized through environment variables.
+These variables can be set in a `.env` file or exported in your shell.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `OPENAI_API_KEY` | API key for OpenAI | - |
+| `LLM_MODEL` | LLM model name | `gpt-4.1-nano` |
+| `POPULATION_SIZE` | Number of population agents to spawn | `36` |
+| `SELF_IMPROVE_AFTER` | Comma separated conversation numbers triggering self improvement | `1,10,35` |
+| `PARALLEL_CONVERSATIONS` | Run conversations concurrently when `true` | `true` |
+| `DSPY_MIPRO_MINIBATCH_SIZE` | Mini-batch size for DSPy Mipro optimizer | `4` |
+| `DSPY_BOOTSTRAP_MINIBATCH_SIZE` | Mini-batch size for DSPy bootstrap optimizer | `2` |
+| `MAX_TURNS` | Turns per conversation | `6` |
+| `HISTORY_BUFFER_LIMIT` | Stored conversations retained by the wizard | `50` |
+| `LOG_LEVEL` | Verbosity of runtime logs | `INFO` |
+


### PR DESCRIPTION
## Summary
- make config options environment-driven
- document options in README and new Configuration guide
- show example settings in `.env.example`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866eb5ba368832481d7d6eb7afe1c2f