### PR TITLE
Clarify log storage and directory creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ export OPENAI_API_KEY=sk-...
 python main.py
 ```
 
+Logs are written to the `logs/` directory, which is created automatically if it
+does not already exist.
+
 To launch the (currently experimental) dashboard run:
 ```bash
 python main.py --dashboard
@@ -71,6 +74,7 @@ This project provides a simplified backend demonstrating a multi-agent research 
 
 All runtime logs are stored in the `logs/` directory. The folder is kept under version control using a `.gitkeep` file, while other log files are ignored via `.gitignore`.
 The main application writes to `logs/system.log` and `logs/token_usage.json`.
+`StructuredLogger` and the token tracker automatically create the `logs/` directory if it is missing.
 
 Use the helper script `scripts/clean_logs.py` to archive or clear old log files.
 

--- a/core/structured_logger.py
+++ b/core/structured_logger.py
@@ -7,7 +7,7 @@ LOG_FILE = Path("logs/system.log")
 
 class StructuredLogger:
     def __init__(self):
-        LOG_FILE.parent.mkdir(exist_ok=True)
+        LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
         self.file = LOG_FILE.open("a")
 
     def log(self, message: str, **kwargs: Any):

--- a/core/token_tracker.py
+++ b/core/token_tracker.py
@@ -19,7 +19,7 @@ class TokenTracker:
         self.save()
 
     def save(self):
-        LOG_FILE.parent.mkdir(exist_ok=True)
+        LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
         LOG_FILE.write_text(json.dumps(self.data, indent=2))
 
 


### PR DESCRIPTION
## Summary
- mention default log directory in Quick Start
- describe automatic creation of `logs/` in the Logs section
- ensure `StructuredLogger` and token tracker always create the directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866eb5e6c708324b86195768251a7f3