### PR TITLE
Load env automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Install dependencies and templates then run the analysis simulation:
 ```bash
 pip install -r requirements.txt
 python scripts/create_templates.py  # if templates are missing
-export OPENAI_API_KEY=sk-...
+# create a .env file or export the API key
+echo "OPENAI_API_KEY=sk-..." > .env
 python main.py
 ```
 

--- a/config.py
+++ b/config.py
@@ -1,5 +1,11 @@
 import os
 from typing import List
+from pathlib import Path
+from dotenv import load_dotenv
+
+# Load environment variables from a .env file if present. This must happen
+# before accessing os.environ so that configuration below picks up the values.
+load_dotenv(dotenv_path=Path(__file__).with_name('.env'), override=False)
 
 # Basic configuration loaded from environment variables
 POPULATION_SIZE = int(os.environ.get("POPULATION_SIZE", 36))

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,7 +1,7 @@
 # Configuration
 
 The application can be customized through environment variables.
-These variables can be set in a `.env` file or exported in your shell.
+Variables defined in a `.env` file are loaded automatically, or you can export them in your shell.
 
 | Variable | Description | Default |
 |----------|-------------|---------|

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,11 +12,11 @@ Follow these steps to set up the project locally.
    pip install -r requirements.txt
    ```
 3. Optionally create default templates if you have not done so.
-   ```bash
-   python scripts/create_templates.py
-   ```
-4. Set your OpenAI API key.
-   ```bash
-   export OPENAI_API_KEY=sk-...
-   ```
+ ```bash
+ python scripts/create_templates.py
+ ```
+4. Set your OpenAI API key in a `.env` file or export it.
+  ```bash
+  echo "OPENAI_API_KEY=sk-..." > .env
+  ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -3,9 +3,9 @@
 Common issues and how to resolve them.
 
 ## Missing OpenAI key
-If you encounter `Missing OPENAI_API_KEY` errors, ensure that the environment variable is set:
+If you encounter `Missing OPENAI_API_KEY` errors, ensure that the environment variable is set or present in a `.env` file:
 ```bash
-export OPENAI_API_KEY=sk-...
+echo "OPENAI_API_KEY=sk-..." > .env
 ```
 
 ## Templates not found

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,6 +1,6 @@
 # Usage
 
-This project demonstrates a simplified multi-agent research system. Once the dependencies are installed and the `OPENAI_API_KEY` is exported, you can run the simulation or launch the dashboard.
+This project demonstrates a simplified multi-agent research system. Once the dependencies are installed and the `OPENAI_API_KEY` is available (either exported or placed in a `.env` file), you can run the simulation or launch the dashboard.
 
 ## Running the analysis simulation
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ numpy
 pandas
 dspy-ai
 pytest
+python-dotenv

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,22 @@
+import importlib
+from pathlib import Path
+
+
+def test_env_file_loading(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    env_file.write_text("OPENAI_API_KEY=test-key\n")
+
+    import dotenv
+
+    real_load = dotenv.load_dotenv
+
+    def fake_load(dotenv_path=None, override=False):
+        return real_load(dotenv_path=env_file, override=override)
+
+    monkeypatch.setattr("dotenv.load_dotenv", fake_load)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    cfg = importlib.import_module("config")
+    importlib.reload(cfg)
+
+    assert cfg.OPENAI_API_KEY == "test-key"


### PR DESCRIPTION
## Summary
- load `.env` on startup in `config.py`
- document `.env` usage in README and docs
- add python-dotenv dependency
- test automatic `.env` loading

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686797da18bc8324b8b96f1c7eff5744