### PR TITLE
Fix token usage tracking for langchain output

### DIFF
--- a/agents/judge_agent.py
+++ b/agents/judge_agent.py
@@ -13,7 +13,11 @@ class EnhancedJudgeAgent:
     def judge(self, conversation_log: dict) -> dict:
         prompt = f"Evaluate the following conversation: {conversation_log}"
         resp = self.llm.invoke([HumanMessage(content=prompt)])
-        tracker.add_usage(resp.usage.prompt_tokens, resp.usage.completion_tokens)
+        if getattr(resp, "usage_metadata", None):
+            tracker.add_usage(
+                resp.usage_metadata.input_tokens,
+                resp.usage_metadata.output_tokens,
+            )
         result = {"overall": 0.8, "success": True}
         self.logger.log("judged", result=result)
         return result

--- a/agents/population_agent.py
+++ b/agents/population_agent.py
@@ -18,11 +18,17 @@ class PopulationAgent:
         prompt = [SystemMessage(content=self.system_instruction),
                   HumanMessage(content="Introduce yourself briefly.")]
         resp = self.llm.invoke(prompt)
-        tracker.add_usage(resp.usage.prompt_tokens, resp.usage.completion_tokens)
+        if getattr(resp, "usage_metadata", None):
+            tracker.add_usage(resp.usage_metadata.input_tokens,
+                             resp.usage_metadata.output_tokens)
         return resp.content
 
     def respond_to(self, message: str) -> str:
-        resp = self.llm.invoke([SystemMessage(content=self.system_instruction),
-                               HumanMessage(content=message)])
-        tracker.add_usage(resp.usage.prompt_tokens, resp.usage.completion_tokens)
+        resp = self.llm.invoke([
+            SystemMessage(content=self.system_instruction),
+            HumanMessage(content=message),
+        ])
+        if getattr(resp, "usage_metadata", None):
+            tracker.add_usage(resp.usage_metadata.input_tokens,
+                             resp.usage_metadata.output_tokens)
         return resp.content

--- a/agents/wizard_agent.py
+++ b/agents/wizard_agent.py
@@ -28,7 +28,11 @@ class WizardAgent:
         message_history = [SystemMessage(content=self.current_prompt), HumanMessage(content=intro)]
         for _ in range(config.MAX_TURNS):
             resp = self.llm.invoke(message_history)
-            tracker.add_usage(resp.usage.prompt_tokens, resp.usage.completion_tokens)
+            if getattr(resp, "usage_metadata", None):
+                tracker.add_usage(
+                    resp.usage_metadata.input_tokens,
+                    resp.usage_metadata.output_tokens,
+                )
             wizard_reply = resp.content
             log["turns"].append({"speaker": "wizard", "text": wizard_reply})
             pop_resp = pop_agent.respond_to(wizard_reply)


### PR DESCRIPTION
## Summary
- update agents to read `usage_metadata` from LangChain responses
- adjust token tracking accordingly

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6867a9a49f788324b71845972140c0c2