### PR TITLE
Fix usage_metadata handling for dictionaries

### DIFF
--- a/agents/judge_agent.py
+++ b/agents/judge_agent.py
@@ -2,6 +2,7 @@ from langchain_openai import ChatOpenAI
 from langchain.schema import HumanMessage, SystemMessage
 from core.structured_logger import StructuredLogger
 from core.token_tracker import tracker
+from core.utils import get_usage_tokens
 
 class EnhancedJudgeAgent:
     def __init__(self, judge_id: str, improvement_interval: int = 20):
@@ -14,10 +15,8 @@ class EnhancedJudgeAgent:
         prompt = f"Evaluate the following conversation: {conversation_log}"
         resp = self.llm.invoke([HumanMessage(content=prompt)])
         if getattr(resp, "usage_metadata", None):
-            tracker.add_usage(
-                resp.usage_metadata.input_tokens,
-                resp.usage_metadata.output_tokens,
-            )
+            prompt_tokens, completion_tokens = get_usage_tokens(resp.usage_metadata)
+            tracker.add_usage(prompt_tokens, completion_tokens)
         result = {"overall": 0.8, "success": True}
         self.logger.log("judged", result=result)
         return result

--- a/agents/population_agent.py
+++ b/agents/population_agent.py
@@ -4,6 +4,7 @@ from langchain_openai import ChatOpenAI
 from langchain.schema import SystemMessage, HumanMessage
 
 from core.token_tracker import tracker
+from core.utils import get_usage_tokens
 
 @dataclass
 class PopulationAgent:
@@ -19,8 +20,8 @@ class PopulationAgent:
                   HumanMessage(content="Introduce yourself briefly.")]
         resp = self.llm.invoke(prompt)
         if getattr(resp, "usage_metadata", None):
-            tracker.add_usage(resp.usage_metadata.input_tokens,
-                             resp.usage_metadata.output_tokens)
+            prompt_tokens, completion_tokens = get_usage_tokens(resp.usage_metadata)
+            tracker.add_usage(prompt_tokens, completion_tokens)
         return resp.content
 
     def respond_to(self, message: str) -> str:
@@ -29,6 +30,6 @@ class PopulationAgent:
             HumanMessage(content=message),
         ])
         if getattr(resp, "usage_metadata", None):
-            tracker.add_usage(resp.usage_metadata.input_tokens,
-                             resp.usage_metadata.output_tokens)
+            prompt_tokens, completion_tokens = get_usage_tokens(resp.usage_metadata)
+            tracker.add_usage(prompt_tokens, completion_tokens)
         return resp.content

--- a/agents/wizard_agent.py
+++ b/agents/wizard_agent.py
@@ -6,6 +6,7 @@ from langchain.schema import SystemMessage, HumanMessage
 
 import config
 from core.token_tracker import tracker
+from core.utils import get_usage_tokens
 from core.structured_logger import StructuredLogger
 
 class WizardAgent:
@@ -29,10 +30,8 @@ class WizardAgent:
         for _ in range(config.MAX_TURNS):
             resp = self.llm.invoke(message_history)
             if getattr(resp, "usage_metadata", None):
-                tracker.add_usage(
-                    resp.usage_metadata.input_tokens,
-                    resp.usage_metadata.output_tokens,
-                )
+                prompt_tokens, completion_tokens = get_usage_tokens(resp.usage_metadata)
+                tracker.add_usage(prompt_tokens, completion_tokens)
             wizard_reply = resp.content
             log["turns"].append({"speaker": "wizard", "text": wizard_reply})
             pop_resp = pop_agent.respond_to(wizard_reply)

--- a/core/utils.py
+++ b/core/utils.py
@@ -29,3 +29,32 @@ def extract_json_array(text: str):
     except Exception:
         return []
 
+
+def get_usage_tokens(usage_meta: Any) -> tuple[int, int]:
+    """Return prompt and completion token counts from usage metadata."""
+    if not usage_meta:
+        return 0, 0
+
+    if isinstance(usage_meta, dict):
+        prompt = (
+            usage_meta.get("input_tokens")
+            or usage_meta.get("prompt_tokens")
+            or 0
+        )
+        completion = (
+            usage_meta.get("output_tokens")
+            or usage_meta.get("completion_tokens")
+            or 0
+        )
+    else:
+        prompt = (
+            getattr(usage_meta, "input_tokens", None)
+            or getattr(usage_meta, "prompt_tokens", 0)
+        )
+        completion = (
+            getattr(usage_meta, "output_tokens", None)
+            or getattr(usage_meta, "completion_tokens", 0)
+        )
+
+    return int(prompt or 0), int(completion or 0)
+

--- a/tests/test_usage_utils.py
+++ b/tests/test_usage_utils.py
@@ -1,0 +1,17 @@
+from types import SimpleNamespace
+from core.utils import get_usage_tokens
+
+
+def test_get_usage_tokens_dict():
+    usage = {"input_tokens": 1, "output_tokens": 2}
+    assert get_usage_tokens(usage) == (1, 2)
+
+
+def test_get_usage_tokens_dict_alt_keys():
+    usage = {"prompt_tokens": 3, "completion_tokens": 4}
+    assert get_usage_tokens(usage) == (3, 4)
+
+
+def test_get_usage_tokens_object():
+    usage = SimpleNamespace(input_tokens=5, output_tokens=6)
+    assert get_usage_tokens(usage) == (5, 6)


### PR DESCRIPTION
## Summary
- handle dict-style `usage_metadata`
- add helper `get_usage_tokens`
- record token usage consistently
- cover new helper with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867ac4a915c8324bb98a013155411c8