### PR TITLE
Add console logging for runtime actions

### DIFF
--- a/advanced_features.py
+++ b/advanced_features.py
@@ -14,7 +14,9 @@ class PopulationGenerator:
         self.logger = StructuredLogger()
 
     def generate(self, instruction: str, n: int) -> List[dict]:
+        self.logger.log("population_generation_start", instruction=instruction, count=n)
         if not TEMPLATE_PATH.exists():
+            self.logger.log("population_template_missing")
             return self._fallback_personas(n)
         template = TEMPLATE_PATH.read_text()
         prompt = template.format(instruction=instruction, n=n)
@@ -24,12 +26,14 @@ class PopulationGenerator:
             candidates = extract_json_array(resp.content)
             if not candidates:
                 raise ValueError("parse failed")
+            self.logger.log("population_generated", generated=len(candidates))
             return candidates
         except Exception as e:
-            self.logger.log("population_generate_error", error=str(e))
+            self.logger.log("population_generate_error", level="error", error=str(e))
             return self._fallback_personas(n)
 
     def _fallback_personas(self, n: int) -> List[dict]:
+        self.logger.log("population_fallback", count=n)
         base = {"name": "Person", "age": 30, "experience": "general"}
         return [dict(base, name=f"Person{i}") for i in range(1, n + 1)]
 

--- a/agents/god_agent.py
+++ b/agents/god_agent.py
@@ -18,4 +18,9 @@ class GodAgent:
         persona = spec
         instruction = f"You are {persona.get('name')} with hearing loss experience: {persona.get('experience', '')}."
         agent = PopulationAgent(agent_id=agent_id, system_instruction=instruction, spec=spec)
+        self.logger.log(
+            "spawned_agent",
+            agent_id=agent_id,
+            persona=persona.get("name"),
+        )
         return agent

--- a/agents/judge_agent.py
+++ b/agents/judge_agent.py
@@ -12,6 +12,7 @@ class EnhancedJudgeAgent:
         self.improvement_interval = improvement_interval
 
     def judge(self, conversation_log: dict) -> dict:
+        self.logger.log("judge_start", conversation=conversation_log.get("pop_agent_id"))
         prompt = f"Evaluate the following conversation: {conversation_log}"
         resp = self.llm.invoke([HumanMessage(content=prompt)])
         if getattr(resp, "usage_metadata", None):

--- a/agents/wizard_agent.py
+++ b/agents/wizard_agent.py
@@ -23,6 +23,7 @@ class WizardAgent:
 
     def converse_with(self, pop_agent) -> Dict:
         log = {"wizard_id": self.wizard_id, "pop_agent_id": pop_agent.agent_id, "turns": []}
+        self.logger.log("conversation_start", agent_id=pop_agent.agent_id)
         intro = pop_agent.introduce()
         log["turns"].append({"speaker": "pop", "text": intro})
 
@@ -36,9 +37,19 @@ class WizardAgent:
             log["turns"].append({"speaker": "wizard", "text": wizard_reply})
             pop_resp = pop_agent.respond_to(wizard_reply)
             log["turns"].append({"speaker": "pop", "text": pop_resp})
+            self.logger.log(
+                "conversation_turn",
+                wizard_reply=wizard_reply,
+                pop_reply=pop_resp,
+            )
             message_history.append(HumanMessage(content=pop_resp))
         self.conversation_count += 1
         self.history_buffer.append(log)
+        self.logger.log(
+            "conversation_end",
+            agent_id=pop_agent.agent_id,
+            turns=len(log["turns"]),
+        )
         return log
 
     def add_judge_feedback(self, result: Dict):

--- a/core/structured_logger.py
+++ b/core/structured_logger.py
@@ -1,7 +1,10 @@
 import json
+import logging
 from pathlib import Path
 from datetime import datetime
 from typing import Any, Dict
+
+import config
 
 LOG_FILE = Path("logs/system.log")
 
@@ -10,8 +13,24 @@ class StructuredLogger:
         LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
         self.file = LOG_FILE.open("a")
 
-    def log(self, message: str, **kwargs: Any):
+        # Configure console logging once
+        self.logger = logging.getLogger("AIgent")
+        if not self.logger.handlers:
+            level = getattr(logging, config.LOG_LEVEL.upper(), logging.INFO)
+            self.logger.setLevel(level)
+            handler = logging.StreamHandler()
+            handler.setLevel(level)
+            formatter = logging.Formatter(
+                "%(asctime)s - %(levelname)s - %(message)s", "%H:%M:%S"
+            )
+            handler.setFormatter(formatter)
+            self.logger.addHandler(handler)
+
+    def log(self, message: str, level: str = "info", **kwargs: Any):
         entry = {"time": datetime.utcnow().isoformat(), "message": message, **kwargs}
         self.file.write(json.dumps(entry) + "\n")
         self.file.flush()
+
+        log_method = getattr(self.logger, level, self.logger.info)
+        log_method(f"{message}: {kwargs}")
 

--- a/core/token_tracker.py
+++ b/core/token_tracker.py
@@ -22,6 +22,10 @@ class TokenTracker:
         LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
         LOG_FILE.write_text(json.dumps(self.data, indent=2))
 
+    def get_totals(self) -> Dict[str, int]:
+        """Return total token usage for the current run."""
+        return self.data.get(self.current_run, {"prompt": 0, "completion": 0})
+
 
 # Global instance
 tracker = TokenTracker()

--- a/main.py
+++ b/main.py
@@ -25,6 +25,9 @@ def validate_environment():
 
 def run_simulation():
     validate_environment()
+    print(
+        f"Starting run with POPULATION_SIZE={config.POPULATION_SIZE}, LLM_MODEL={config.LLM_MODEL}"
+    )
     system = IntegratedSystem()
     system.run()
 


### PR DESCRIPTION
## Summary
- configure console logging in `StructuredLogger`
- improve population generation logs
- log new agent spawn events
- print conversation turns and run summaries
- expose token usage totals
- show config info at startup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867aeaef0408324aed4f4377d2bda29