### PR TITLE
Document console log configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ This will start a simple Flask app that displays a placeholder page.
 All runtime logs are stored in the `logs/` directory. The folder is kept under version control using a `.gitkeep` file, while other log files are ignored via `.gitignore`.
 The main application writes to `logs/system.log` and `logs/token_usage.json`.
 `StructuredLogger` and the token tracker automatically create the `logs/` directory if it is missing.
+Console output is controlled by the `LOG_LEVEL` environment variable and mirrors
+the structured entries written to `logs/system.log`.
 
 Use the helper script `scripts/clean_logs.py` to archive or clear old log files.
 Use `scripts/analyze_results.py` to summarize log statistics.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,3 +16,6 @@ Variables defined in a `.env` file are loaded automatically, or you can export t
 | `HISTORY_BUFFER_LIMIT` | Stored conversations retained by the wizard | `50` |
 | `LOG_LEVEL` | Verbosity of runtime logs | `INFO` |
 
+Logs are printed to the console according to `LOG_LEVEL` and simultaneously
+written to `logs/system.log` in structured JSON format.
+


### PR DESCRIPTION
## Summary
- explain that runtime logs are echoed to the console
- note this in the configuration docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867b31807a883249fc7c4f299fbf62d