### PR TITLE
Improve persona logging

### DIFF
--- a/agents/god_agent.py
+++ b/agents/god_agent.py
@@ -13,18 +13,36 @@ class GodAgent:
         self.console = ConsoleLogger()
 
     def spawn_population_from_spec(self, spec: Dict, run_no: int, idx: int):
+        """Instantiate a PopulationAgent from a persona specification."""
         from agents.population_agent import PopulationAgent
 
-        timestamp = datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')
+        timestamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
         agent_id = f"{run_no}.{idx}_{timestamp}"
+
         persona = spec
-        instruction = f"You are {persona.get('name')} with hearing loss experience: {persona.get('experience', '')}."
-        agent = PopulationAgent(agent_id=agent_id, system_instruction=instruction, spec=spec)
-        self.logger.log(
-            "spawned_agent",
-            agent_id=agent_id,
-            persona=persona.get("name"),
+        name = persona.get("name")
+        if not name:
+            # Ensure every persona has a name for clearer logs
+            self.logger.log(
+                "persona_missing_name",
+                level="warning",
+                agent_id=agent_id,
+                spec=persona,
+            )
+            name = "Unknown"
+            persona["name"] = name
+
+        instruction = (
+            f"You are {name} with hearing loss experience: "
+            f"{persona.get('experience', '')}."
         )
+
+        agent = PopulationAgent(
+            agent_id=agent_id, system_instruction=instruction, spec=persona
+        )
+
+        # Log the full persona specification for traceability
+        self.logger.log("spawned_agent", agent_id=agent_id, persona=persona)
         self.console.log(f"Spawned agent {agent_id}")
         return agent
 

--- a/templates/population_instruction.txt
+++ b/templates/population_instruction.txt
@@ -1,1 +1,3 @@
-Generate {n} personas experiencing hearing loss as JSON array.
+Generate {n} personas experiencing hearing loss as a JSON array. Each persona
+must be a dictionary that includes a "name" field and any other relevant
+information.


### PR DESCRIPTION
## Summary
- warn if persona name is missing
- log complete persona specs when GodAgent spawns population agents
- clarify population template so generated personas contain a `name` field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867b62b02f88324b734779b5b2b0402