### PR TITLE
Add DSPy dataset helpers and tests

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,3 +1,4 @@
 from .structured_logger import StructuredLogger
 from .console_logger import ConsoleLogger
+from .dspy_utils import build_dataset, get_miprov2
 

--- a/core/dspy_utils.py
+++ b/core/dspy_utils.py
@@ -1,0 +1,53 @@
+# DSPy integration helpers
+from collections import deque
+from typing import Iterable, Any
+
+from dspy.datasets.dataset import Dataset
+from dspy.teleprompt.mipro_optimizer_v2 import MIPROv2
+
+import config
+
+
+def build_dataset(history: deque) -> Dataset:
+    """Return a DSPy Dataset of (conversation, score) records.
+
+    Each entry in ``history`` should either be a tuple ``(log, score)`` or
+    a mapping with ``"turns"`` and ``"score"`` keys. ``log`` is expected to have
+    a ``"turns"`` list of ``{"speaker": str, "text": str}`` dictionaries and
+    ``score`` may be a number or a mapping with an ``"overall"`` field.
+    """
+    records = []
+    for item in history:
+        if isinstance(item, tuple) and len(item) == 2:
+            conv_log, score = item
+        elif isinstance(item, dict):
+            conv_log = item
+            score = item.get("score")
+        else:
+            continue
+
+        turns = conv_log.get("turns", [])
+        convo = "\n".join(f"{t.get('speaker')}: {t.get('text')}" for t in turns)
+        if isinstance(score, dict):
+            score_val = score.get("overall")
+        else:
+            score_val = score
+        records.append({"conversation": convo, "score": score_val})
+
+    ds = Dataset(train_size=len(records), dev_size=0, test_size=0, input_keys=["conversation"])
+    ds._train = records
+    ds._dev = []
+    ds._test = []
+    return ds
+
+
+def get_miprov2(metric, prompt_model=None, task_model=None) -> MIPROv2:
+    """Return a configured MIPROv2 optimizer instance."""
+    return MIPROv2(
+        metric=metric,
+        prompt_model=prompt_model,
+        task_model=task_model,
+        max_bootstrapped_demos=config.DSPY_BOOTSTRAP_MINIBATCH_SIZE,
+        max_labeled_demos=config.DSPY_MIPRO_MINIBATCH_SIZE,
+    )
+

--- a/tests/test_dspy_utils.py
+++ b/tests/test_dspy_utils.py
@@ -1,0 +1,28 @@
+from collections import deque
+import config
+from core.dspy_utils import build_dataset, get_miprov2
+from dspy.teleprompt.mipro_optimizer_v2 import MIPROv2
+
+
+def test_build_dataset_basic():
+    history = deque([
+        ({"turns": [{"speaker": "wiz", "text": "hi"}, {"speaker": "pop", "text": "ok"}]}, {"overall": 0.7}),
+        ({"turns": [{"speaker": "wiz", "text": "bye"}]}, {"overall": 0.5}),
+    ])
+    ds = build_dataset(history)
+    train = ds.train
+    assert len(train) == 2
+    assert train[0].conversation == "wiz: hi\npop: ok"
+    assert train[0].score == 0.7
+
+
+def dummy_metric(*args, **kwargs):
+    return 0.0
+
+
+def test_get_miprov2_configured():
+    opt = get_miprov2(dummy_metric)
+    assert isinstance(opt, MIPROv2)
+    assert opt.max_labeled_demos == config.DSPY_MIPRO_MINIBATCH_SIZE
+    assert opt.max_bootstrapped_demos == config.DSPY_BOOTSTRAP_MINIBATCH_SIZE
+


### PR DESCRIPTION
## Summary
- create `core/dspy_utils.py` with helper functions
- export helpers from `core/__init__.py`
- add unit tests for building datasets and configuring MIPROv2

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867e6861cac8324ac9c98a2685e005b