### PR TITLE
Add DSPy optimization helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This project provides a simplified backend demonstrating a multi-agent research 
 - [Usage](docs/usage.md)
 - [Configuration](docs/configuration.md)
 - [Troubleshooting](docs/troubleshooting.md)
+- [Prompt Optimization](docs/prompt_optimization.md)
 
 ## Architecture Overview
 

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,3 +1,3 @@
 from .structured_logger import StructuredLogger
 from .console_logger import ConsoleLogger
-
+from .dspy_utils import apply_dspy_optimizer

--- a/core/dspy_utils.py
+++ b/core/dspy_utils.py
@@ -1,0 +1,41 @@
+"""DSPy helper utilities."""
+
+from __future__ import annotations
+
+from typing import Callable, List, Any
+
+from dspy.teleprompt import BootstrapFewShot, MIPROv2
+
+import config
+
+
+def apply_dspy_optimizer(student: Any, metric: Callable, trainset: List) -> Any:
+    """Return a DSPy program optimized with BootstrapFewShot and MIPROv2.
+
+    Parameters
+    ----------
+    student : Any
+        DSPy module or program to optimize.
+    metric : Callable
+        Scoring function used by the optimizers.
+    trainset : List
+        Example training data.
+
+    Returns
+    -------
+    Any
+        The optimized DSPy program.
+    """
+
+    bootstrap = BootstrapFewShot(
+        metric=metric,
+        max_labeled_demos=config.DSPY_BOOTSTRAP_MINIBATCH_SIZE,
+    )
+    student = bootstrap.compile(student, trainset=trainset)
+
+    mipro = MIPROv2(
+        metric=metric,
+        max_bootstrapped_demos=config.DSPY_MIPRO_MINIBATCH_SIZE,
+    )
+    student = mipro.compile(student, trainset=trainset)
+    return student

--- a/docs/prompt_optimization.md
+++ b/docs/prompt_optimization.md
@@ -1,0 +1,27 @@
+# Prompt Optimization
+
+The project includes a small helper in `core/dspy_utils.py` for refining DSPy programs.
+
+## `apply_dspy_optimizer`
+
+`apply_dspy_optimizer(student, metric, trainset)` runs DSPy's `BootstrapFewShot` and
+`MIPROv2` optimizers using batch sizes defined in `config.py`. It returns the
+optimized DSPy program.
+
+Population agents or the `GodAgent` can optionally call this function to improve
+their prompts. A minimal example looks like this:
+
+```python
+from core.dspy_utils import apply_dspy_optimizer
+from agents.population_agent import PopulationAgent
+
+def metric(example, pred):
+    return 1.0  # implement your scoring logic
+
+agent = PopulationAgent(agent_id="A1", system_instruction="...", spec={})
+student_program = agent.system_instruction  # or a DSPy Module producing it
+optimized = apply_dspy_optimizer(student_program, metric, trainset=["demo"])
+```
+
+Replace `metric` and `trainset` with your own evaluation function and examples.
+The returned program can be used by the agent in subsequent runs.

--- a/tests/test_dspy_utils.py
+++ b/tests/test_dspy_utils.py
@@ -1,0 +1,28 @@
+from core.dspy_utils import apply_dspy_optimizer
+
+class DummyProgram:
+    pass
+
+class _MockBS:
+    def __init__(self, metric, max_labeled_demos):
+        self.init_args = (metric, max_labeled_demos)
+    def compile(self, student, trainset, teacher=None, valset=None):
+        student.bs_called = True
+        return student
+
+class _MockMipro:
+    def __init__(self, metric, max_bootstrapped_demos):
+        self.init_args = (metric, max_bootstrapped_demos)
+    def compile(self, student, trainset, teacher=None, valset=None, **kw):
+        student.mipro_called = True
+        return student
+
+
+def test_apply_dspy_optimizer(monkeypatch):
+    monkeypatch.setattr('core.dspy_utils.BootstrapFewShot', _MockBS)
+    monkeypatch.setattr('core.dspy_utils.MIPROv2', _MockMipro)
+    prog = DummyProgram()
+    optimized = apply_dspy_optimizer(prog, metric=lambda x,y:0, trainset=[1])
+    assert optimized is prog
+    assert getattr(optimized, 'bs_called', False)
+    assert getattr(optimized, 'mipro_called', False)


### PR DESCRIPTION
## Summary
- add `apply_dspy_optimizer` helper for sequential DSPy optimizations
- export helper from `core.__init__`
- document prompt optimization usage for agents
- register new documentation page in README
- test helper logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867e69d86cc8324b6ca08183a401385