### PR TITLE
Add numeric scoring for judge agent

### DIFF
--- a/agents/judge_agent.py
+++ b/agents/judge_agent.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+import re
 from langchain_openai import ChatOpenAI
 from langchain.schema import HumanMessage, SystemMessage
 from core.structured_logger import StructuredLogger
@@ -14,14 +16,36 @@ class EnhancedJudgeAgent:
         self.improvement_interval = improvement_interval
 
     def judge(self, conversation_log: dict) -> dict:
+        """Score a conversation on a 0-1 scale using an LLM prompt."""
         self.logger.log("judge_start", conversation=conversation_log.get("pop_agent_id"))
         self.console.log(f"Judging {conversation_log.get('pop_agent_id')}")
-        prompt = f"Evaluate the following conversation: {conversation_log}"
-        resp = self.llm.invoke([HumanMessage(content=prompt)])
+
+        template_path = Path("templates/judge_prompt.txt")
+        if template_path.exists():
+            template = template_path.read_text()
+        else:
+            template = (
+                "Evaluate the conversation and return a score between 0 and 1"
+            )
+
+        turns = conversation_log.get("turns", [])
+        conv_text = "\n".join(f"{t.get('speaker')}: {t.get('text')}" for t in turns)
+
+        messages = [SystemMessage(content=template), HumanMessage(content=conv_text)]
+        resp = self.llm.invoke(messages)
+
         if getattr(resp, "usage_metadata", None):
             prompt_tokens, completion_tokens = get_usage_tokens(resp.usage_metadata)
             tracker.add_usage(prompt_tokens, completion_tokens)
-        result = {"overall": 0.8, "success": True}
+
+        match = re.search(r"([0-9]*\.?[0-9]+)", resp.content)
+        try:
+            score = float(match.group(1)) if match else 0.0
+        except Exception:
+            score = 0.0
+        score = max(0.0, min(score, 1.0))
+
+        result = {"overall": score, "success": score >= 0.5}
         self.logger.log("judged", result=result)
         self.console.log(f"Judge result {result}")
         return result

--- a/tests/test_judge_agent.py
+++ b/tests/test_judge_agent.py
@@ -1,0 +1,28 @@
+import types
+from agents.judge_agent import EnhancedJudgeAgent
+from core import token_tracker
+
+class DummyResp:
+    def __init__(self, content="0.6"):
+        self.content = content
+        self.usage_metadata = {"prompt_tokens": 1, "completion_tokens": 1}
+
+def test_judge_parses_score(monkeypatch, tmp_path):
+    agent = EnhancedJudgeAgent("J")
+    monkeypatch.setattr(agent, "llm", types.SimpleNamespace(invoke=lambda msgs: DummyResp("0.75")))
+    monkeypatch.setattr(token_tracker, "LOG_FILE", tmp_path / "usage.json")
+    token_tracker.tracker.set_run(1)
+    log = {"pop_agent_id": "A", "turns": [{"speaker": "pop", "text": "hi"}]}
+    result = agent.judge(log)
+    assert result["overall"] == 0.75
+    assert result["success"] is True
+
+def test_judge_handles_bad_output(monkeypatch, tmp_path):
+    agent = EnhancedJudgeAgent("J")
+    monkeypatch.setattr(agent, "llm", types.SimpleNamespace(invoke=lambda msgs: DummyResp("n/a")))
+    monkeypatch.setattr(token_tracker, "LOG_FILE", tmp_path / "usage.json")
+    token_tracker.tracker.set_run(1)
+    log = {"pop_agent_id": "A", "turns": []}
+    result = agent.judge(log)
+    assert result["overall"] == 0.0
+    assert result["success"] is False


### PR DESCRIPTION
## Summary
- implement numerical scoring in `EnhancedJudgeAgent.judge`
- add tests for judge scoring

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867e69e58308324b8ffb67fc084c10c