### PR TITLE
Add improver type to prompts log

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ agent.system_instruction = apply_dspy_optimizer(agent.system_instruction,
 All runtime logs are stored in the `logs/` directory. The folder is kept under version control using a `.gitkeep` file, while other log files are ignored via `.gitignore`.
 The main application writes to `logs/system.log` and `logs/token_usage.json`.
 Any prompts refined during self-improvement are appended to
-`logs/improved_prompts.log`.
+`logs/improved_prompts.log`. Each entry stores the improved prompt, the
+average score across the history and the DSPy improver type that generated it.
 `StructuredLogger` and the token tracker automatically create the `logs/` directory if it is missing.
 Console output is controlled by the `LOG_LEVEL` environment variable and mirrors
 the structured entries written to `logs/system.log`.

--- a/agents/wizard_agent.py
+++ b/agents/wizard_agent.py
@@ -91,6 +91,7 @@ class WizardAgent:
             self.history_buffer,
             get_opt=get_miprov2,
         )
+        improver_type = type(get_miprov2(lambda *_: 0)).__name__
         avg_score = 0.0
         scores = [c.get("score") or 0 for c in self.history_buffer]
         if scores:
@@ -99,6 +100,7 @@ class WizardAgent:
             "id": f"improved_prompts_wizzard_{self.run_no}.{self.conversation_count}",
             "prompt": self.current_prompt,
             "avg_score": avg_score,
+            "improver": improver_type,
         }
         IMPROVED_PROMPTS_LOG.parent.mkdir(parents=True, exist_ok=True)
         with IMPROVED_PROMPTS_LOG.open("a") as f:

--- a/tests/test_dspy_opt.py
+++ b/tests/test_dspy_opt.py
@@ -2,6 +2,7 @@ import dspy
 import importlib.util
 import sys
 import types
+import json
 from pathlib import Path
 
 sys.modules.setdefault(
@@ -47,7 +48,9 @@ def test_self_improve_updates_prompt(monkeypatch, tmp_path):
     agent.self_improve()
     assert agent.current_prompt == improved
     log_entry = (tmp_path / "imp.log").read_text().strip().splitlines()[0]
-    assert improved in log_entry
+    entry = json.loads(log_entry)
+    assert entry["prompt"] == improved
+    assert entry["improver"] == "DummyMIPRO"
 
 
 def test_add_judge_feedback_updates_history():


### PR DESCRIPTION
## Summary
- include `improver` field when logging improved prompts
- document new field in README
- test improver logging in `test_self_improve_updates_prompt`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686835ac53b88324922b4eb287d00221