### PR TITLE
Fix logging to use timezone-aware timestamps

### DIFF
--- a/core/structured_logger.py
+++ b/core/structured_logger.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict
 
 import config
@@ -27,7 +27,11 @@ class StructuredLogger:
             self.logger.addHandler(handler)
 
     def log(self, message: str, level: str = "info", **kwargs: Any):
-        entry = {"time": datetime.utcnow().isoformat(), "message": message, **kwargs}
+        entry = {
+            "time": datetime.now(timezone.utc).isoformat(),
+            "message": message,
+            **kwargs,
+        }
         self.file.write(json.dumps(entry) + "\n")
         self.file.flush()
 


### PR DESCRIPTION
## Summary
- update `StructuredLogger` to use timezone-aware timestamps
- clear `datetime.utcnow` deprecation warning

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868408cd37483248a4203d7b0d8c2a9