### PR TITLE
Improve DSPy integration

### DIFF
--- a/tests/test_dspy_opt.py
+++ b/tests/test_dspy_opt.py
@@ -35,8 +35,9 @@ def test_self_improve_updates_prompt(monkeypatch, tmp_path):
     class DummyMIPRO:
         def __init__(self, metric):
             pass
-        def compile(self, current_prompt, *, trainset):
-            return improved
+        def compile(self, program, *, trainset):
+            program.signature.__doc__ = improved
+            return program
 
     monkeypatch.setattr(wizard_agent, "get_miprov2", lambda *a, **k: DummyMIPRO(*a, **k))
     monkeypatch.setattr(wizard_agent, "IMPROVED_PROMPTS_LOG", tmp_path / "imp.log")

--- a/tests/test_dspy_utils.py
+++ b/tests/test_dspy_utils.py
@@ -1,6 +1,7 @@
 from collections import deque
 import config
-from core.dspy_utils import build_dataset, get_miprov2, apply_dspy_optimizer
+from core.dspy_utils import build_dataset, get_miprov2, apply_dspy_optimizer, prompt_program
+import dspy
 from dspy.teleprompt.mipro_optimizer_v2 import MIPROv2
 
 
@@ -27,6 +28,12 @@ def test_get_miprov2_configured():
     assert opt.max_bootstrapped_demos == config.DSPY_BOOTSTRAP_MINIBATCH_SIZE
 
 
+def test_prompt_program_wraps_text():
+    prog = prompt_program("hello")
+    assert isinstance(prog, dspy.Predict)
+    assert prog.signature.__doc__ == "hello"
+
+
 def test_apply_dspy_optimizer(monkeypatch):
     history = deque([
         ({"turns": [{"speaker": "pop", "text": "hi"}]}, {"overall": 0.5}),
@@ -37,8 +44,9 @@ def test_apply_dspy_optimizer(monkeypatch):
         def __init__(self, metric, prompt_model=None, task_model=None):
             pass
 
-        def compile(self, prompt, *, trainset):
-            return improved
+        def compile(self, program, *, trainset):
+            program.signature.__doc__ = improved
+            return program
 
     monkeypatch.setattr("core.dspy_utils.get_miprov2", lambda *a, **k: DummyOpt(*a, **k))
     result = apply_dspy_optimizer("orig", history)

--- a/tests/test_mipro_debug.py
+++ b/tests/test_mipro_debug.py
@@ -25,9 +25,10 @@ def test_miprov2_self_improve(monkeypatch, tmp_path):
     improved = "optimized"
     called = {"flag": False}
 
-    def fake_compile(self, prompt, *, trainset):
+    def fake_compile(self, program, *, trainset):
         called["flag"] = True
-        return improved
+        program.signature.__doc__ = improved
+        return program
 
     monkeypatch.setattr(MIPROv2, "compile", fake_compile)
 


### PR DESCRIPTION
## Summary
- add `prompt_program` helper to wrap prompts in a minimal DSPy program
- use this program when applying DSPy optimizers
- update tests for new optimizer workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868481c6dcc83249f8690c500ae9236